### PR TITLE
feat: add avatar component

### DIFF
--- a/app/views/pages/home.templ
+++ b/app/views/pages/home.templ
@@ -4,6 +4,7 @@ import (
 	"github.com/CalumMackenzie-Chambers/templ-ui/components/button"
 	"github.com/CalumMackenzie-Chambers/templ-ui/components/accordion"
 	"github.com/CalumMackenzie-Chambers/templ-ui/components/alert"
+	"github.com/CalumMackenzie-Chambers/templ-ui/components/avatar"
 )
 
 templ Home() {
@@ -155,7 +156,7 @@ templ Home() {
 				<div class="max-w-xl">
 					@alert.Alert(alert.AlertProps{
 								Variant: alert.Danger,
-								Icon: alert.Warning(),  // or any appropriate icon
+								Icon: alert.Warning(),
 								Title: "Danger Alert",
 								Text: "This is the danger alert variant that uses the danger color as foreground with base background and border colors.",
 						})
@@ -163,12 +164,17 @@ templ Home() {
 				<div class="max-w-xl">
 					@alert.Alert(alert.AlertProps{
 								Variant: alert.DangerMuted,
-								Icon: alert.Warning(),  // or any appropriate icon
+								Icon: alert.Warning(),
 								Title: "Danger Muted Alert",
 								Text: "This is the danger muted alert variant that uses the danger color as foreground with danger-muted background and border colors - Use with caution, may not pass accessibility.",
 						})
 				</div>
 			</div>
+		</section>
+		<section class="space-y-4">
+			<h2 class="text-2xl lg:text3xl font-bold">Avatar</h2>
+			@avatar.Avatar("https://avatars.githubusercontent.com/u/87911622?v=4", "CM")
+			@avatar.AvatarSvg()
 		</section>
 	</main>
 }

--- a/components/avatar/avatar.templ
+++ b/components/avatar/avatar.templ
@@ -1,0 +1,15 @@
+package avatar;
+
+templ Avatar(url string, placeholder string) {
+	<span class="relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full">
+		<img src={ url } class="aspect-square flex h-full w-full items-center justify-center rounded-full bg-muted-background overflow-hidden" alt={ placeholder } loading="lazy" height="10" width="10"/>
+	</span>
+}
+
+templ AvatarSvg() {
+	<span class="relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full">
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="aspect-square flex h-full w-full items-center justify-center rounded-full bg-muted-background overflow-hidden pt-2 px-1">
+			<path fill-rule="evenodd" d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z" clip-rule="evenodd"></path>
+		</svg>
+	</span>
+}


### PR DESCRIPTION
# Pull Request

## Description

Added an avatar component. The avatar has a default fallback of two letters / initials. There is an alternative version that just has a fixed svg background.

closes #5 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] Other (please specify)

## How to Test

Avatar section of component page

## Screenshots

<img width="135" alt="image" src="https://github.com/CalumMackenzie-Chambers/templ-ui/assets/87911622/57cc7bb3-d99f-47a6-a518-7ea58ffabc69">

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] The relevant issue is linked above
